### PR TITLE
Only show users courses from their school

### DIFF
--- a/src/main/java/com/personal/springbootpractice/InitDatabase.java
+++ b/src/main/java/com/personal/springbootpractice/InitDatabase.java
@@ -16,10 +16,10 @@ public class InitDatabase {
     @Bean
     public CommandLineRunner initialize(MongoOperations ops) {
         return args -> {
-            ops.insert(new Course("Newly Made Course!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30));
-            ops.insert(new Course( "Newly Made Course 2.0!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30));
-            ops.insert(new Course("This is an old course lol!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30));
-
+            ops.insert(new Course("Newly Made Course!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30, "UCSD"));
+            ops.insert(new Course( "Newly Made Course 2.0!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30, "UCSD"));
+            ops.insert(new Course("This is an old course lol!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30, "UCSD"));
+            
             ops.findAll(Course.class).forEach(System.out::println);
         };
     }

--- a/src/main/java/com/personal/springbootpractice/controllers/CourseController.java
+++ b/src/main/java/com/personal/springbootpractice/controllers/CourseController.java
@@ -1,8 +1,10 @@
 package com.personal.springbootpractice.controllers;
 
 import com.personal.springbootpractice.models.Course;
+import com.personal.springbootpractice.models.User;
 import com.personal.springbootpractice.repositories.CourseRepository;
 import com.personal.springbootpractice.util.AuthenticationUtils;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,9 +35,10 @@ public class CourseController {
      * @return A string containing the name of the corresponding HTML file to which the user will be sent to
      */
     @GetMapping("/allcourses")
-    public Mono<String> allCourses(Model model) {
+    public Mono<String> allCourses(Model model, @AuthenticationPrincipal User user) {
+
         model.addAttribute("isAuthenticated", AuthenticationUtils.isAuthenticated());
-        model.addAttribute("courses", repository.findAll().sort());
+        model.addAttribute("courses", repository.findAllBySchoolName(user.getSchoolName()).sort());
         model.addAttribute("course", new Course());
         return Mono.just("Courses");
     }
@@ -46,7 +49,8 @@ public class CourseController {
      * @return A redirect to the "/allcourses" page
      */
     @PostMapping("/courses/new")
-    public Mono<String> newCourse(@ModelAttribute(value="course") Course course) {
+    public Mono<String> newCourse(@ModelAttribute(value="course") Course course, @AuthenticationPrincipal User user) {
+        course.setSchoolName(user.getSchoolName());
         System.out.println(course);
         // Solution to the issue of getting form data from POST form: https://stackoverflow.com/questions/17669212/send-datas-from-html-to-controller-in-thymeleaf
         // Solution to the date type mismatch error: https://stackoverflow.com/questions/53188464/spring-boot-date-conversion-from-form

--- a/src/main/java/com/personal/springbootpractice/controllers/CourseRestController.java
+++ b/src/main/java/com/personal/springbootpractice/controllers/CourseRestController.java
@@ -29,7 +29,7 @@ public class CourseRestController {
     // This would be changed to a POST mapping
     @GetMapping("/api/courses/new/{id}")
     public Mono<String> addNewCourse(@PathVariable("id") Long id) {
-        Course courseToAdd = new Course("Newly Made Course!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30);
+        Course courseToAdd = new Course("Newly Made Course!", new Date(), Date.from(Instant.now().plus(90, ChronoUnit.DAYS)), 30, "UCSD");
 
         return repository.save(courseToAdd).then(Mono.just("Success!"));
     }

--- a/src/main/java/com/personal/springbootpractice/models/Course.java
+++ b/src/main/java/com/personal/springbootpractice/models/Course.java
@@ -20,15 +20,17 @@ public class Course implements Comparable<Course> {
     private Date startDate;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date endDate;
+    private String schoolName;
     
     private int maxStudents;
 
-    public Course(String courseName, Date startDate, Date endDate, int maxStudents) {
+    public Course(String courseName, Date startDate, Date endDate, int maxStudents, String schoolName) {
         this.id = new ObjectId().toString();
         this.name = courseName;
         this.startDate = startDate;
         this.endDate = endDate;
         this.maxStudents = maxStudents;
+        this.schoolName = schoolName;
     }
 
     public Course() {

--- a/src/main/java/com/personal/springbootpractice/repositories/CourseRepository.java
+++ b/src/main/java/com/personal/springbootpractice/repositories/CourseRepository.java
@@ -3,9 +3,12 @@ package com.personal.springbootpractice.repositories;
 
 import com.personal.springbootpractice.models.Course;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 
 public interface CourseRepository extends ReactiveCrudRepository<Course, Long> {
     Mono<Course> findById(String id);
+
+    Flux<Course> findAllBySchoolName(String schoolName);
 }


### PR DESCRIPTION
Before, any user could see any course that had been made, but this update makes it so that each user sees courses associated with their school. The Course model was changed to include a String for the name of the school the course belongs to, and a method was added to retrieve courses via their school name, which is used in the "/allcourses" endpoint. 